### PR TITLE
Rename `Ecstacy` -> `Ecstasy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 A small type representation of [Robert Plutchik's](https://en.wikipedia.org/wiki/Robert_Plutchik) ["Wheel of Emotions"](https://en.wikipedia.org/wiki/Contrasting_and_categorization_of_emotions#/media/File:Plutchik-wheel.svg).
 
-- Use labeled `Emotion`s (i.e. `Emotion::Ecstacy`, `Emotion::Terror`, etc).
+- Use labeled `Emotion`s (i.e. `Emotion::Ecstasy`, `Emotion::Terror`, etc).
 - Design custom emotions using the `Wheel { radians: f32, weight: f32 }` representation.
 - Find the difference between two emotions (the magnitude of the vector that separates them on the Wheel).
 - Find the mean emotion of multiple given emotions i.e.

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -8,7 +8,7 @@ fn main() {
     println!("Robert Plutchik's wheel of emotions, typified!");
 
     println!("\nConversions");
-    let start_emotion = Emotion::Ecstacy;
+    let start_emotion = Emotion::Ecstasy;
     let wheel = *start_emotion;
     println!("{:?} to {:?}", &start_emotion, &wheel);
     let vec: [f32; 2] = wheel.into();
@@ -42,7 +42,7 @@ fn main() {
              some_wheel.opposite(), some_wheel.opposite().closest_emotion());
 
     println!("\nMean (Average) Emotion");
-    let emotions = [Emotion::Ecstacy, Emotion::Serenity, Emotion::Admiration, Emotion::Acceptance];
+    let emotions = [Emotion::Ecstasy, Emotion::Serenity, Emotion::Admiration, Emotion::Acceptance];
     let mean = Wheel::mean(&emotions);
     assert!(mean.closest_emotion() == Emotion::Love);
     println!("The mean emotion of Ecstasy, Serenity, Admiration and Acceptance is {:?}! AKA {:?}.",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use std::ops::Deref;
 /// Each of the emotions portrayed on Plutchik's emotion wheel.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Emotion {
-    Ecstacy,
+    Ecstasy,
     Joy,
     Serenity,
     Love,
@@ -59,7 +59,7 @@ pub struct Wheel {
 
 /// The full list of Plutchik's labelled emotions.
 pub const EMOTIONS: &'static [Emotion; 32] = &[
-    Emotion::Ecstacy,
+    Emotion::Ecstasy,
     Emotion::Joy,
     Emotion::Serenity,
     Emotion::Love,
@@ -106,8 +106,8 @@ pub mod wheels {
             pub const $name: &'static Wheel = &Wheel { radians: $radians, weight: $weight };
         };
     }
-    
-    wheel!(ECSTACY        { PI * 0.5    , 0.8 });
+
+    wheel!(ECSTASY        { PI * 0.5    , 0.8 });
     wheel!(JOY            { PI * 0.5    , 0.5 });
     wheel!(SERENITY       { PI * 0.5    , 0.2 });
     wheel!(LOVE           { PI * 0.375  , 0.5 });
@@ -146,7 +146,7 @@ impl Deref for Emotion {
     type Target = Wheel;
     fn deref<'a>(&'a self) -> &'a Wheel {
         match *self {
-            Emotion::Ecstacy        => wheels::ECSTACY,
+            Emotion::Ecstasy        => wheels::ECSTASY,
             Emotion::Joy            => wheels::JOY,
             Emotion::Serenity       => wheels::SERENITY,
             Emotion::Love           => wheels::LOVE,


### PR DESCRIPTION
I think this is a typo, though given my familiarity with the subject I
could be wrong.
